### PR TITLE
Use Document Root

### DIFF
--- a/router.php
+++ b/router.php
@@ -2,11 +2,11 @@
 
 if (preg_match('#^/api/rest#', $_SERVER["REQUEST_URI"])) {
   $_SERVER["REQUEST_URI"] = 'api.php?type=rest';
-} elseif (preg_match('#^/(media|skin|js)#', $_SERVER["REQUEST_URI"])) {
+} elseif (preg_match('#^/(media|skin|js)(?:$|/)#', $path = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH))) {
   return false;
-} elseif (file_exists(".".explode('?',$_SERVER["REQUEST_URI"])[0]))  {
+} elseif (file_exists($_SERVER['DOCUMENT_ROOT'] . $path))  {
   return false;
 } else {
-  include_once 'index.php';
+  chdir ($_SERVER['DOCUMENT_ROOT']);
+  require $_SERVER['DOCUMENT_ROOT'] . '/index.php';
 }
-


### PR DESCRIPTION
If no document root parameter is passed, the internal webserver starts in the current working directory. However, the document root can be specified via a command-line parameter and the router then needs to reflect that setting otherwise Magento can't require important files and will crash.

Additionally the path component from the request URI is parsed now and media, skin and js folders are more properly checked.
